### PR TITLE
Maintain a Generic Name instead of "image"

### DIFF
--- a/rocAL/include/loaders/circular_buffer.h
+++ b/rocAL/include/loaders/circular_buffer.h
@@ -31,8 +31,8 @@ THE SOFTWARE.
 #include "commons.h"
 #include "device_manager.h"
 #include "device_manager_hip.h"
-struct decoded_image_info {
-    std::vector<std::string> _image_names;
+struct decoded_sample_info {
+    std::vector<std::string> _sample_names;
     std::vector<uint32_t> _roi_width;
     std::vector<uint32_t> _roi_height;
     std::vector<uint32_t> _original_width;
@@ -54,9 +54,9 @@ class CircularBuffer {
     void unblock_writer();  // Unblocks the thread currently waiting on get_write_buffer
     void push();            // The latest write goes through, effectively adds one element to the buffer
     void pop();             // The oldest write will be erased and overwritten in upcoming writes
-    void set_image_info(const decoded_image_info& info) { _last_image_info = info; }
+    void set_sample_info(const decoded_sample_info& info) { _last_sample_info = info; }
     void set_crop_image_info(const crop_image_info& info) { _last_crop_image_info = info; }
-    decoded_image_info& get_image_info();
+    decoded_sample_info& get_sample_info();
     crop_image_info& get_cropped_image_info();
     bool random_bbox_crop_flag = false;
     void* get_read_buffer_dev();
@@ -73,8 +73,8 @@ class CircularBuffer {
     bool full();
     bool empty();
     size_t _buff_depth;
-    decoded_image_info _last_image_info;
-    std::queue<decoded_image_info> _circ_image_info;    //!< Stores the loaded images names, decoded_width and decoded_height(data is stored in the _circ_buff)
+    decoded_sample_info _last_sample_info;
+    std::queue<decoded_sample_info> _circ_sample_info;    //!< Stores the loaded sample's names, decoded_width and decoded_height(data is stored in the _circ_buff)
     crop_image_info _last_crop_image_info;              // for Random BBox crop coordinates
     std::queue<crop_image_info> _circ_crop_image_info;  //!< Stores the crop coordinates of the images for random bbox crop (data is stored in the _circ_buff)
     std::mutex _names_buff_lock;

--- a/rocAL/include/loaders/image/cifar10_data_loader.h
+++ b/rocAL/include/loaders/image/cifar10_data_loader.h
@@ -40,7 +40,7 @@ class CIFAR10DataLoader : public LoaderModule {
     void reset() override;
     void start_loading() override;
     std::vector<std::string> get_id() override;
-    decoded_image_info get_decode_image_info() override;
+    decoded_sample_info get_decode_sample_info() override;
     crop_image_info get_crop_image_info() override;
     Timing timing() override;
     void set_prefetch_queue_depth(size_t prefetch_queue_depth) override;
@@ -59,8 +59,8 @@ class CIFAR10DataLoader : public LoaderModule {
     LoaderModuleStatus load_routine();
     std::shared_ptr<Reader> _reader;
     void *_dev_resources;
-    decoded_image_info _raw_img_info;  // image info to store the names. In this case the ID of image is stored in _roi_width field
-    decoded_image_info _output_decoded_img_info;
+    decoded_sample_info _raw_img_info;  // image info to store the names. In this case the ID of image is stored in _roi_width field
+    decoded_sample_info _output_decoded_img_info;
     bool _initialized = false;
     RocalMemType _mem_type;
     size_t _output_mem_size;

--- a/rocAL/include/loaders/image/image_loader.h
+++ b/rocAL/include/loaders/image/image_loader.h
@@ -49,7 +49,7 @@ class ImageLoader : public LoaderModule {
     LoaderModuleStatus set_cpu_sched_policy(struct sched_param sched_policy);
     void set_gpu_device_id(int device_id);
     std::vector<std::string> get_id() override;
-    decoded_image_info get_decode_image_info() override;
+    decoded_sample_info get_decode_sample_info() override;
     crop_image_info get_crop_image_info() override;
     void set_prefetch_queue_depth(size_t prefetch_queue_depth) override;
     void shut_down() override;
@@ -74,9 +74,9 @@ class ImageLoader : public LoaderModule {
     size_t _batch_size;
     std::thread _load_thread;
     RocalMemType _mem_type;
-    decoded_image_info _decoded_img_info;
+    decoded_sample_info _decoded_img_info;
     crop_image_info _crop_image_info;
-    decoded_image_info _output_decoded_img_info;
+    decoded_sample_info _output_decoded_img_info;
     crop_image_info _output_cropped_img_info;
     CircularBuffer _circ_buff;
     TimingDBG _swap_handle_time;

--- a/rocAL/include/loaders/image/image_loader_sharded.h
+++ b/rocAL/include/loaders/image/image_loader_sharded.h
@@ -40,7 +40,7 @@ class ImageLoaderSharded : public LoaderModule {
     void reset() override;
     void start_loading() override;
     std::vector<std::string> get_id() override;
-    decoded_image_info get_decode_image_info() override;
+    decoded_sample_info get_decode_sample_info() override;
     crop_image_info get_crop_image_info() override;
     Timing timing() override;
     void set_prefetch_queue_depth(size_t prefetch_queue_depth) override;

--- a/rocAL/include/loaders/loader_module.h
+++ b/rocAL/include/loaders/loader_module.h
@@ -53,8 +53,8 @@ class LoaderModule {
     virtual Timing timing() = 0;                    // Returns timing info
     virtual std::vector<std::string> get_id() = 0;  // returns the id of the last batch of images/frames loaded
     virtual void start_loading() = 0;               // starts internal loading thread
-    virtual decoded_image_info get_decode_image_info() = 0;
-    virtual crop_image_info get_crop_image_info() = 0;
+    virtual decoded_sample_info get_decode_sample_info() = 0;
+    virtual crop_image_info get_crop_image_info() { return {}; }
     virtual void set_prefetch_queue_depth(size_t prefetch_queue_depth) = 0;
     // introduce meta data reader
     virtual void set_random_bbox_data_reader(std::shared_ptr<RandomBBoxCrop_MetaDataReader> randombboxcrop_meta_data_reader) = 0;

--- a/rocAL/include/loaders/video/video_loader.h
+++ b/rocAL/include/loaders/video/video_loader.h
@@ -49,7 +49,7 @@ class VideoLoader : public LoaderModule {
     LoaderModuleStatus set_cpu_affinity(cpu_set_t cpu_mask);
     LoaderModuleStatus set_cpu_sched_policy(struct sched_param sched_policy);
     std::vector<std::string> get_id() override;
-    decoded_image_info get_decode_image_info() override;
+    decoded_sample_info get_decode_sample_info() override;
     void set_prefetch_queue_depth(size_t prefetch_queue_depth) override;
     crop_image_info get_crop_image_info() override { return _crop_img_info; }
     void set_random_bbox_data_reader(std::shared_ptr<RandomBBoxCrop_MetaDataReader> randombboxcrop_meta_data_reader) override{};
@@ -74,8 +74,8 @@ class VideoLoader : public LoaderModule {
     size_t _sequence_length;
     std::thread _load_thread;
     RocalMemType _mem_type;
-    decoded_image_info _decoded_img_info;
-    decoded_image_info _output_decoded_img_info;
+    decoded_sample_info _decoded_img_info;
+    decoded_sample_info _output_decoded_img_info;
     CircularBuffer _circ_buff;
     TimingDBG _swap_handle_time;
     bool _is_initialized;

--- a/rocAL/include/loaders/video/video_loader_sharded.h
+++ b/rocAL/include/loaders/video/video_loader_sharded.h
@@ -41,7 +41,7 @@ class VideoLoaderSharded : public LoaderModule {
     void reset() override;
     void start_loading() override;
     std::vector<std::string> get_id() override;
-    decoded_image_info get_decode_image_info() override;
+    decoded_sample_info get_decode_sample_info() override;
     void set_prefetch_queue_depth(size_t prefetch_queue_depth) override;
     crop_image_info get_crop_image_info() override { return _crop_img_info; }
     void set_random_bbox_data_reader(std::shared_ptr<RandomBBoxCrop_MetaDataReader> randombboxcrop_meta_data_reader) override{};

--- a/rocAL/include/meta_data/bounding_box_graph.h
+++ b/rocAL/include/meta_data/bounding_box_graph.h
@@ -31,8 +31,8 @@ typedef  struct { float xc; float yc; float w; float h; } BoundingBoxCord_xcycwh
 class BoundingBoxGraph : public MetaDataGraph {
    public:
     void process(pMetaDataBatch input_meta_data, pMetaDataBatch output_meta_data) override;
-    void update_meta_data(pMetaDataBatch meta_data, decoded_image_info decode_image_info) override;
-    void update_random_bbox_meta_data(pMetaDataBatch input_meta_data, pMetaDataBatch output_meta_data, decoded_image_info decoded_image_info, crop_image_info crop_image_info) override;
+    void update_meta_data(pMetaDataBatch meta_data, decoded_sample_info decode_image_info) override;
+    void update_random_bbox_meta_data(pMetaDataBatch input_meta_data, pMetaDataBatch output_meta_data, decoded_sample_info decoded_image_info, crop_image_info crop_image_info) override;
     void update_box_encoder_meta_data(std::vector<float> *anchors, pMetaDataBatch full_batch_meta_data, float criteria, bool offset, float scale, std::vector<float> &means, std::vector<float> &stds, float *encoded_boxes_data, int *encoded_labels_data) override;
     void update_box_iou_matcher(BoxIouMatcherInfo &iou_matcher_info, int *matches_idx_buffer, pMetaDataBatch full_batch_meta_data) override;
 };

--- a/rocAL/include/meta_data/meta_data_graph.h
+++ b/rocAL/include/meta_data/meta_data_graph.h
@@ -41,8 +41,8 @@ class MetaDataGraph {
    public:
     virtual ~MetaDataGraph() = default;
     virtual void process(pMetaDataBatch input_meta_data, pMetaDataBatch output_meta_data) = 0;
-    virtual void update_meta_data(pMetaDataBatch meta_data, decoded_image_info decoded_image_info) = 0;
-    virtual void update_random_bbox_meta_data(pMetaDataBatch input_meta_data, pMetaDataBatch output_meta_data, decoded_image_info decoded_image_info, crop_image_info crop_image_info) = 0;
+    virtual void update_meta_data(pMetaDataBatch meta_data, decoded_sample_info decoded_image_info) = 0;
+    virtual void update_random_bbox_meta_data(pMetaDataBatch input_meta_data, pMetaDataBatch output_meta_data, decoded_sample_info decoded_image_info, crop_image_info crop_image_info) = 0;
     virtual void update_box_encoder_meta_data(std::vector<float> *anchors, pMetaDataBatch full_batch_meta_data, float criteria, bool offset, float scale, std::vector<float> &means, std::vector<float> &stds, float *encoded_boxes_data, int *encoded_labels_data) = 0;
     virtual void update_box_iou_matcher(BoxIouMatcherInfo &iou_matcher_info, int *matches_idx_buffer, pMetaDataBatch full_batch_meta_data) = 0;
     std::list<std::shared_ptr<MetaNode>> _meta_nodes;

--- a/rocAL/source/loaders/circular_buffer.cpp
+++ b/rocAL/source/loaders/circular_buffer.cpp
@@ -40,8 +40,8 @@ void CircularBuffer::reset() {
     _write_ptr = 0;
     _read_ptr = 0;
     _level = 0;
-    while (!_circ_image_info.empty())
-        _circ_image_info.pop();
+    while (!_circ_sample_info.empty())
+        _circ_sample_info.pop();
     if (random_bbox_crop_flag == true) {
         while (!_circ_crop_image_info.empty())
             _circ_crop_image_info.pop();
@@ -135,7 +135,7 @@ void CircularBuffer::push() {
     sync();
     // Pushing to the _circ_buff and _circ_buff_names must happen all at the same time
     std::unique_lock<std::mutex> lock(_names_buff_lock);
-    _circ_image_info.push(_last_image_info);
+    _circ_sample_info.push(_last_sample_info);
     if (random_bbox_crop_flag == true)
         _circ_crop_image_info.push(_last_crop_image_info);
     increment_write_ptr();
@@ -147,7 +147,7 @@ void CircularBuffer::pop() {
     // Pushing to the _circ_buff and _circ_buff_names must happen all at the same time
     std::unique_lock<std::mutex> lock(_names_buff_lock);
     increment_read_ptr();
-    _circ_image_info.pop();
+    _circ_sample_info.pop();
     if (random_bbox_crop_flag == true)
         _circ_crop_image_info.pop();
 }
@@ -338,12 +338,12 @@ CircularBuffer::~CircularBuffer() {
     _initialized = false;
 }
 
-decoded_image_info &CircularBuffer::get_image_info() {
+decoded_sample_info &CircularBuffer::get_sample_info() {
     block_if_empty();
     std::unique_lock<std::mutex> lock(_names_buff_lock);
-    if (_level != _circ_image_info.size())
-        THROW("CircularBuffer internals error, image and image info sizes not the same " + TOSTR(_level) + " != " + TOSTR(_circ_image_info.size()))
-    return _circ_image_info.front();
+    if (_level != _circ_sample_info.size())
+        THROW("CircularBuffer internals error, sample and sample info sizes not the same " + TOSTR(_level) + " != " + TOSTR(_circ_sample_info.size()))
+    return _circ_sample_info.front();
 }
 
 crop_image_info &CircularBuffer::get_cropped_image_info() {

--- a/rocAL/source/loaders/image/cifar10_data_loader.cpp
+++ b/rocAL/source/loaders/image/cifar10_data_loader.cpp
@@ -119,7 +119,7 @@ void CIFAR10DataLoader::initialize(ReaderConfig reader_cfg, DecoderConfig decode
         throw;
     }
     _actual_read_size.resize(batch_size);
-    _raw_img_info._image_names.resize(_batch_size);
+    _raw_img_info._sample_names.resize(_batch_size);
     _raw_img_info._roi_width.resize(_batch_size);  // used to store the individual image in a big raw file
     _raw_img_info._roi_height.resize(batch_size);
     _raw_img_info._original_height.resize(_batch_size);
@@ -182,7 +182,7 @@ CIFAR10DataLoader::load_routine() {
                     continue;
                 }
                 _actual_read_size[file_counter] = _reader->read_data(read_ptr, readSize);
-                _raw_img_info._image_names[file_counter] = _reader->id();
+                _raw_img_info._sample_names[file_counter] = _reader->id();
                 _raw_img_info._roi_width[file_counter] = _output_tensor->info().max_shape()[0];
                 _raw_img_info._roi_height[file_counter] = _output_tensor->info().max_shape()[1];
                 _reader->close();
@@ -190,13 +190,13 @@ CIFAR10DataLoader::load_routine() {
             }
             if (_randombboxcrop_meta_data_reader) {
                 // Fetch the crop co-ordinates for a batch of images
-                _bbox_coords = _randombboxcrop_meta_data_reader->get_batch_crop_coords(_raw_img_info._image_names);
+                _bbox_coords = _randombboxcrop_meta_data_reader->get_batch_crop_coords(_raw_img_info._sample_names);
                 set_batch_random_bbox_crop_coords(_bbox_coords);
                 _crop_image_info._crop_image_coords = get_batch_random_bbox_crop_coords();
                 _circ_buff.set_crop_image_info(_crop_image_info);
             }
             _file_load_time.end();  // Debug timing
-            _circ_buff.set_image_info(_raw_img_info);
+            _circ_buff.set_sample_info(_raw_img_info);
             _circ_buff.push();
             _image_counter += _output_tensor->info().batch_size();
             load_status = LoaderModuleStatus::OK;
@@ -254,11 +254,11 @@ CIFAR10DataLoader::update_output_image() {
     if (_stopped)
         return LoaderModuleStatus::OK;
 
-    _output_decoded_img_info = _circ_buff.get_image_info();
+    _output_decoded_img_info = _circ_buff.get_sample_info();
     if (_randombboxcrop_meta_data_reader) {
         _output_cropped_image_info = _circ_buff.get_cropped_image_info();
     }
-    _output_names = _output_decoded_img_info._image_names;
+    _output_names = _output_decoded_img_info._sample_names;
     _output_tensor->update_tensor_roi(_output_decoded_img_info._roi_width, _output_decoded_img_info._roi_height);
 
     _circ_buff.pop();
@@ -279,7 +279,7 @@ std::vector<std::string> CIFAR10DataLoader::get_id() {
     return _output_names;
 }
 
-decoded_image_info CIFAR10DataLoader::get_decode_image_info() {
+decoded_sample_info CIFAR10DataLoader::get_decode_sample_info() {
     return _output_decoded_img_info;
 }
 

--- a/rocAL/source/loaders/image/image_loader.cpp
+++ b/rocAL/source/loaders/image/image_loader.cpp
@@ -152,7 +152,7 @@ void ImageLoader::initialize(ReaderConfig reader_cfg, DecoderConfig decoder_cfg,
     }
     _max_tensor_width = _output_tensor->info().max_shape().at(0);
     _max_tensor_height = _output_tensor->info().max_shape().at(1);
-    _decoded_img_info._image_names.resize(_batch_size);
+    _decoded_img_info._sample_names.resize(_batch_size);
     _decoded_img_info._roi_height.resize(_batch_size);
     _decoded_img_info._roi_width.resize(_batch_size);
     _decoded_img_info._original_height.resize(_batch_size);
@@ -187,7 +187,7 @@ ImageLoader::load_routine() {
         auto load_status = LoaderModuleStatus::NO_MORE_DATA_TO_READ;
         {
             load_status = _image_loader->load(data,
-                                              _decoded_img_info._image_names,
+                                              _decoded_img_info._sample_names,
                                               _max_tensor_width,
                                               _max_tensor_height,
                                               _decoded_img_info._roi_width,
@@ -201,7 +201,7 @@ ImageLoader::load_routine() {
                     _crop_image_info._crop_image_coords = _image_loader->get_batch_random_bbox_crop_coords();
                     _circ_buff.set_crop_image_info(_crop_image_info);
                 }
-                _circ_buff.set_image_info(_decoded_img_info);
+                _circ_buff.set_sample_info(_decoded_img_info);
                 _circ_buff.push();
                 _image_counter += _output_tensor->info().batch_size();
             }
@@ -259,11 +259,11 @@ ImageLoader::update_output_image() {
     if (_stopped)
         return LoaderModuleStatus::OK;
 
-    _output_decoded_img_info = _circ_buff.get_image_info();
+    _output_decoded_img_info = _circ_buff.get_sample_info();
     if (_randombboxcrop_meta_data_reader) {
         _output_cropped_img_info = _circ_buff.get_cropped_image_info();
     }
-    _output_names = _output_decoded_img_info._image_names;
+    _output_names = _output_decoded_img_info._sample_names;
     _output_tensor->update_tensor_roi(_output_decoded_img_info._roi_width, _output_decoded_img_info._roi_height);
     _circ_buff.pop();
     if (!_loop)
@@ -307,7 +307,7 @@ std::vector<std::string> ImageLoader::get_id() {
     return _output_names;
 }
 
-decoded_image_info ImageLoader::get_decode_image_info() {
+decoded_sample_info ImageLoader::get_decode_sample_info() {
     return _output_decoded_img_info;
 }
 

--- a/rocAL/source/loaders/image/image_loader_sharded.cpp
+++ b/rocAL/source/loaders/image/image_loader_sharded.cpp
@@ -38,8 +38,8 @@ std::vector<std::string> ImageLoaderSharded::get_id() {
     return _loaders[_loader_idx]->get_id();
 }
 
-decoded_image_info ImageLoaderSharded::get_decode_image_info() {
-    return _loaders[_loader_idx]->get_decode_image_info();
+decoded_sample_info ImageLoaderSharded::get_decode_sample_info() {
+    return _loaders[_loader_idx]->get_decode_sample_info();
 }
 
 crop_image_info ImageLoaderSharded::get_crop_image_info() {

--- a/rocAL/source/loaders/video/video_loader.cpp
+++ b/rocAL/source/loaders/video/video_loader.cpp
@@ -131,7 +131,7 @@ void VideoLoader::initialize(ReaderConfig reader_cfg, DecoderConfig decoder_cfg,
     }
     _max_tensor_width = _output_tensor->info().max_shape().at(0);
     _max_tensor_height = _output_tensor->info().max_shape().at(1);
-    _decoded_img_info._image_names.resize(_batch_size);
+    _decoded_img_info._sample_names.resize(_batch_size);
     _decoded_img_info._roi_height.resize(_batch_size);
     _decoded_img_info._roi_width.resize(_batch_size);
     _decoded_img_info._original_height.resize(_batch_size);
@@ -163,7 +163,7 @@ VideoLoader::load_routine() {
         auto load_status = LoaderModuleStatus::NO_MORE_DATA_TO_READ;
         {
             load_status = _video_loader->load(data,
-                                              _decoded_img_info._image_names,
+                                              _decoded_img_info._sample_names,
                                               _max_tensor_width,
                                               _max_tensor_height,
                                               _decoded_img_info._roi_width,
@@ -175,7 +175,7 @@ VideoLoader::load_routine() {
                                               _output_tensor->info().color_format());
 
             if (load_status == LoaderModuleStatus::OK) {
-                _circ_buff.set_image_info(_decoded_img_info);
+                _circ_buff.set_sample_info(_decoded_img_info);
                 _circ_buff.push();
                 _image_counter += _output_tensor->info().batch_size();
             }
@@ -233,8 +233,8 @@ VideoLoader::update_output_image() {
     }
     if (_stopped)
         return LoaderModuleStatus::OK;
-    _output_decoded_img_info = _circ_buff.get_image_info();
-    _output_names = _output_decoded_img_info._image_names;
+    _output_decoded_img_info = _circ_buff.get_sample_info();
+    _output_names = _output_decoded_img_info._sample_names;
     _output_tensor->update_tensor_roi(_output_decoded_img_info._roi_width, _output_decoded_img_info._roi_height);
     _circ_buff.pop();
     if (!_loop)
@@ -277,7 +277,7 @@ std::vector<std::string> VideoLoader::get_id() {
     return _output_names;
 }
 
-decoded_image_info VideoLoader::get_decode_image_info() {
+decoded_sample_info VideoLoader::get_decode_sample_info() {
     return _output_decoded_img_info;
 }
 

--- a/rocAL/source/loaders/video/video_loader_sharded.cpp
+++ b/rocAL/source/loaders/video/video_loader_sharded.cpp
@@ -39,8 +39,8 @@ std::vector<std::string> VideoLoaderSharded::get_id() {
     return _loaders[_loader_idx]->get_id();
 }
 
-decoded_image_info VideoLoaderSharded::get_decode_image_info() {
-    return _loaders[_loader_idx]->get_decode_image_info();
+decoded_sample_info VideoLoaderSharded::get_decode_sample_info() {
+    return _loaders[_loader_idx]->get_decode_sample_info();
 }
 
 VideoLoaderSharded::~VideoLoaderSharded() {

--- a/rocAL/source/meta_data/bounding_box_graph.cpp
+++ b/rocAL/source/meta_data/bounding_box_graph.cpp
@@ -31,7 +31,7 @@ void BoundingBoxGraph::process(pMetaDataBatch input_meta_data, pMetaDataBatch ou
 }
 
 // This function is used to rescale the metadata values w.r.t the decoded image sizes
-void BoundingBoxGraph::update_meta_data(pMetaDataBatch input_meta_data, decoded_image_info decode_image_info) {
+void BoundingBoxGraph::update_meta_data(pMetaDataBatch input_meta_data, decoded_sample_info decode_image_info) {
     std::vector<uint32_t> original_height = decode_image_info._original_height;
     std::vector<uint32_t> original_width = decode_image_info._original_width;
     std::vector<uint32_t> roi_width = decode_image_info._roi_width;
@@ -68,7 +68,7 @@ inline float ssd_BBoxIntersectionOverUnion(const BoundingBoxCord &box1, const fl
     return (float)(intersection_area / (box1_area + box2_area - intersection_area));
 }
 
-void BoundingBoxGraph::update_random_bbox_meta_data(pMetaDataBatch input_meta_data, pMetaDataBatch output_meta_data, decoded_image_info decode_image_info, crop_image_info crop_image_info) {
+void BoundingBoxGraph::update_random_bbox_meta_data(pMetaDataBatch input_meta_data, pMetaDataBatch output_meta_data, decoded_sample_info decode_image_info, crop_image_info crop_image_info) {
     std::vector<uint32_t> original_height = decode_image_info._original_height;
     std::vector<uint32_t> original_width = decode_image_info._original_width;
     std::vector<uint32_t> roi_width = decode_image_info._roi_width;

--- a/rocAL/source/pipeline/master_graph.cpp
+++ b/rocAL/source/pipeline/master_graph.cpp
@@ -903,16 +903,16 @@ void MasterGraph::output_routine() {
                 THROW("Loader module failed to load next batch of images, status " + TOSTR(load_ret))
             if (!_processing)
                 break;
-            auto full_batch_image_names = _loader_module->get_id();
-            auto decode_image_info = _loader_module->get_decode_image_info();
+            auto full_batch_sample_names = _loader_module->get_id();
+            auto decode_sample_info = _loader_module->get_decode_sample_info();
             auto crop_image_info = _loader_module->get_crop_image_info();
 
-            if (full_batch_image_names.size() != _user_batch_size)
-                WRN("Internal problem: names count " + TOSTR(full_batch_image_names.size()))
+            if (full_batch_sample_names.size() != _user_batch_size)
+                WRN("Internal problem: names count " + TOSTR(full_batch_sample_names.size()))
 
             // meta_data lookup is done before _meta_data_graph->process() is called to have the new meta_data ready for processing
             if (_meta_data_reader)
-                _meta_data_reader->lookup(full_batch_image_names);
+                _meta_data_reader->lookup(full_batch_sample_names);
 
             if (!_processing)
                 break;
@@ -936,9 +936,9 @@ void MasterGraph::output_routine() {
                 output_meta_data = _augmented_meta_data->clone(!_augmentation_metanode);  // copy the data if metadata is not processed by the nodes, else create an empty instance
                 if (_meta_data_graph) {
                     if (_is_random_bbox_crop) {
-                        _meta_data_graph->update_random_bbox_meta_data(_augmented_meta_data, output_meta_data, decode_image_info, crop_image_info);
+                        _meta_data_graph->update_random_bbox_meta_data(_augmented_meta_data, output_meta_data, decode_sample_info, crop_image_info);
                     } else {
-                        _meta_data_graph->update_meta_data(_augmented_meta_data, decode_image_info);
+                        _meta_data_graph->update_meta_data(_augmented_meta_data, decode_sample_info);
                     }
                     _meta_data_graph->process(_augmented_meta_data, output_meta_data);
                 }
@@ -970,7 +970,7 @@ void MasterGraph::output_routine() {
             _sequence_start_framenum_vec.insert(_sequence_start_framenum_vec.begin(), _loader_module->get_sequence_start_frame_number());
             _sequence_frame_timestamps_vec.insert(_sequence_frame_timestamps_vec.begin(), _loader_module->get_sequence_frame_timestamps());
 #endif
-            _ring_buffer.set_meta_data(full_batch_image_names, output_meta_data);
+            _ring_buffer.set_meta_data(full_batch_sample_names, output_meta_data);
             _ring_buffer.push();  // Image data and metadata is now stored in output the ring_buffer, increases it's level by 1
         }
     } catch (const std::exception &e) {


### PR DESCRIPTION
Change names of image_info to sample_info to maintain a generic name for all use-cases